### PR TITLE
fix: diff deployment order need change

### DIFF
--- a/pkg/cluster/deployment/deployment.go
+++ b/pkg/cluster/deployment/deployment.go
@@ -105,7 +105,7 @@ func CreateOrUpdate(
 					logrus.Warnf("found hpa %s/%s for deployment %s/%s with error: %v", hpa.Namespace, hpa.Name, deploy.Namespace, deploy.Name, err)
 				} else {
 					generatedDeploy.Spec.Replicas = deploy.Spec.Replicas
-					if diff.IsDeploymentEqual(*generatedDeploy, *deploy) {
+					if diff.IsDeploymentEqual(*deploy, *generatedDeploy) {
 						logrus.Warnf("skip update deployment %s/%s replicas with hpa %s/%s, can not update deployment replicas when hpa enable, you can update other configs or disable hpa for updating replicas and try again", deploy.Namespace, deploy.Name, hpa.Namespace, hpa.Name)
 						return deploy, nil
 					}


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
when update deployment which enabled with hpa, need call diff.IsDeploymentEqual(d1, d2), the `d1` must means 'current' and  the `d2` must means 'target'. 

#### Specified Reviewers:

/assign @iutx 


